### PR TITLE
Update to call command

### DIFF
--- a/pages/install-guide.md
+++ b/pages/install-guide.md
@@ -105,10 +105,10 @@ Response: {
 }
 ```
 
-Query service
+Call service
 
 ```shell
-$ micro query go.micro.srv.greeter Say.Hello '{"name": "John"}'
+$ micro call go.micro.srv.greeter Say.Hello '{"name": "John"}'
 {
 	"msg": "Hello John"
 }


### PR DESCRIPTION
`micro query [service]` is deprecated. `micro call [service]` should be used instead.