### PR TITLE
Remove extra space in command to run micro api

### DIFF
--- a/pages/toolkit.md
+++ b/pages/toolkit.md
@@ -268,7 +268,7 @@ Let's run it so we can query the example service.
 
 ```
 MICRO_API_HANDLER=rpc \
-MICRO_API_NAMESPACE=go.micro.srv \ 
+MICRO_API_NAMESPACE=go.micro.srv \
 micro api
 ```
 


### PR DESCRIPTION
The extra space gave an output like this :

```
$ MICRO_API_HANDLER=rpc \
MICRO_API_NAMESPACE=go.micro.srv \
micro api
zsh: command not found:  
2019/03/12 23:15:37 Registering RPC Handler at /rpc
2019/03/12 23:15:37 Registering API Default Handler at /
2019/03/12 23:15:37 HTTP API Listening on [::]:8080
2019/03/12 23:15:37 Transport [http] Listening on [::]:58327
2019/03/12 23:15:37 Broker [http] Connected to [::]:58328
2019/03/12 23:15:37 Registry [mdns] Registering node: go.micro.api-6abc527d-bd8f-403a-8bd8-735bea95dc62
```

Notice the `command not found`. That's due to the extra space. Also, due to this, the environment variable didn't get set properly and hence the curl showed a 500 internal server error

```
{"id":"go.micro.api","code":500,"detail":"not found","status":"Internal Server Error"}
```

That's how I got suspicious and noticed this issue and that the below command was working fine

`MICRO_API_HANDLER=rpc MICRO_API_NAMESPACE=go.micro.srv micro api`

Crazy spaces 😅 Let me know if this makes sense and if the issue is reproducible in your machine too. In which case I think we can merge this 😄 