### PR TITLE
fix typo

### DIFF
--- a/pages/writing-a-go-service.md
+++ b/pages/writing-a-go-service.md
@@ -292,7 +292,7 @@ Querying the above service is as simple as the following.
 
 ```go
 // create the greeter client using the service name and client
-greeter := proto.NewGreeterClient("greeter", service.Client())
+greeter := proto.NewGreeterService("greeter", service.Client())
 
 // request the Hello method on the Greeter handler
 rsp, err := greeter.Hello(context.TODO(), &proto.HelloRequest{


### PR DESCRIPTION
According to [examples/service/main.go line 29](https://github.com/micro/examples/blob/210612de508ab0ce0aada9fa960a84ce279716c4/service/main.go#L29), here should goes "NewGreeterService" instead of "NewGreeterClient", the latter one will produce a "Too many arguments in call" error